### PR TITLE
Allow connection to frida-gadget

### DIFF
--- a/src/HookManager.js
+++ b/src/HookManager.js
@@ -1156,9 +1156,18 @@ HookManager.prototype.start = function(hook_script){
  
         const device = yield FRIDA.getUsbDevice(10000);
         console.log('usb device:', device);
-    
-        const pid = yield device.spawn([APP]);
-        console.log('spawned:', pid);
+
+        const applications = yield device.enumerateApplications();
+        console.log('[*] Applications:', applications);
+        var pid = -1;
+        if(applications.length == 1 && applications[0].name == "Gadget") {
+            console.log('only found gadget, assuming there is no frid-server');
+            pid = applications[0].pid; 
+        }
+        else {
+            const pid = yield device.spawn([APP]);
+            console.log('spawned:', pid);
+        }
         
         const session = yield device.attach(pid);
         console.log('attached:', session);


### PR DESCRIPTION
If you one does not want to Root the device (which is needed to install frida-server), one can inject the libfrida-gadget.so into the APK (extract it, add lib, modify smali, repack, install). Currently dexcalibur was spawning the process to start dynamic analysis, but since the device is not rooted, forking of another app is not allowed (the frida-gadget announces itself as "Gadget", and in the source code it checks if "Gadget" == app_identifier, which is false).

In this commit I check if the only application which is running is called "Gadget" and if so, it just attaches itself to the process instead of spawning a new one. 

With this fix, I could use dexcalibur without rooting my device.

Cheers