### PR TITLE
New Dex reading stack and Minor fixes

### DIFF
--- a/src/Analyzer.js
+++ b/src/Analyzer.js
@@ -614,11 +614,15 @@ function MakeMap(data,absoluteDB){
             // here v.extends is the string not a Class instance
             ext = v.getSuperClass();
 
-
+            try {
             if(ext != null && cls.hasSuperClass() && ext!=cls.getSuperClass().getName()){
                 cls.updateSuper(Resolver.type(absoluteDB, ext));
                 requireRemap = true;
             }
+        }
+        catch(ex) {
+            console.error(ex);
+        }
         }
         else if(cls.getSuperClass() != null && (!cls.getSuperClass() instanceof CLASS.Class)){
             cls.extends = Resolver.type(absoluteDB, cls.extends);

--- a/src/HookManager.js
+++ b/src/HookManager.js
@@ -1161,7 +1161,7 @@ HookManager.prototype.start = function(hook_script){
         console.log('[*] Applications:', applications);
         var pid = -1;
         if(applications.length == 1 && applications[0].name == "Gadget") {
-            console.log('only found gadget, assuming there is no frid-server');
+            console.log('only found gadget, assuming there is no frida-server');
             pid = applications[0].pid; 
         }
         else {

--- a/src/HookManager.js
+++ b/src/HookManager.js
@@ -1156,9 +1156,18 @@ HookManager.prototype.start = function(hook_script){
  
         const device = yield FRIDA.getUsbDevice(10000);
         console.log('usb device:', device);
-    
-        const pid = yield device.spawn([APP]);
-        console.log('spawned:', pid);
+
+        const applications = yield device.enumerateApplications();
+        console.log('[*] Applications:', applications);
+        var pid = -1;
+        if(applications.length == 1 && applications[0].name == "Gadget") {
+            console.log('only found gadget, assuming there is no frid-server');
+            pid = applications[0].pid; 
+        }
+        else {
+            const pid = yield device.spawn([APP]);
+            console.log('spawned:', pid);
+        }
         
         const session = yield device.attach(pid);
         console.log('attached:', session);

--- a/src/HookManager.js
+++ b/src/HookManager.js
@@ -1165,7 +1165,7 @@ HookManager.prototype.start = function(hook_script){
             pid = applications[0].pid; 
         }
         else {
-            const pid = yield device.spawn([APP]);
+            pid = yield device.spawn([APP]);
             console.log('spawned:', pid);
         }
         

--- a/src/requires/Common.js
+++ b/src/requires/Common.js
@@ -45,11 +45,21 @@ DEXC_MODULE.common.readFile = function(input_file){
     var fin = DEXC_MODULE.common.class.java.io.FileInputStream.$new(input_file);
     var content = [];
     var b=null;
+    var jsBuffer = new Uint8Array(4096);
+    var buffer = Java.array('byte', jsBuffer);
+    var lastSize = 0;
     do{
-        b=fin.read();
-        content.push(b);
+        b=fin.read(buffer);
+        if(b != -1) {
+            //console.log("read " + b + " bytes, writing it into a JS array");
+            for(var i =0; i < b; i++) {
+                content.push(buffer[i]);
+            }
+        }
     }while(b != -1);
-
+    
+    
+    console.log("finished flatting array");
     return content;
 }
 


### PR DESCRIPTION
I added a try and catch in the Analyser, since it crashed after analysing a Dex File which was not compiled with the same target SDK as Dexcalibur is/was using. I am not quite sure what the implications are, but in my case it was working and I could browse the decompiled newly loaded dex class. I guess it just does not overwrite the graph tree of the android SDK, so one might get wrong results, when one is heavily relying on SDK functions in the dynamically loaded Dex. 

In any case, it should not crash, but probably warn the user better than it is done now (I did not quite look into error reporting, I just print the stack trace to the logs)

On another note, I corrected a spelling mistake in my previous pull request (frid-server -> frida-server)

Furthermore, I noticed that the code for copying the newly compiled Dex File over was reading every single Byte. In my case it took forever to copy a 2MB Dex file. So I was playing around with different other possibilities. I found that reading the file in a buffer first and then add it to the array shows slight performance increase, although I did not do any benchmarks. So could as well be placebo. Nevertheless one should focus more on this issue I think, since it is not practical to have to wait for 3 minutes to copy a 2 MB file :-D


Anyways, your Project is awesome! And I hope you continue the great work!


P.S. Have you considered including a Debugger? I was fiddling around with the JDWP stuff and Smalidea and I think it could be a real nice addition to allow debugging.

On another note, have you looked into the InMemoryDexClassLoader? Because the current Hooks don't include it, and I wasn't able to add a Hook for it (since it cannot find the signature, I guess since it was introduced in API Level 26?). 