### PR TITLE
Package manager fixed

### DIFF
--- a/dexcalibur
+++ b/dexcalibur
@@ -1,5 +1,6 @@
-#!/usr/bin/node --max-old-space-size=8192
-// #!/usr/local/bin/node --max-old-space-size=8192
+#!/usr/local/bin/node --max-old-space-size=8192
+//#!/usr/bin/node --max-old-space-size=8192
+
 
 const Dexcalibur = require("./src/Project.js");
 const ArgParser = require("./src/ArgUtils.js");
@@ -101,9 +102,9 @@ if(projectArgs.app != null){
     
     var Project = null ;
     if(projectArgs.config != null){
-        Project = new Dexcalibur(projectArgs.app, projectArgs.config, projectArgs.nofrida);
+        Project = new Dexcalibur(projectArgs.app, projectArgs.config, projectArgs.nofrida, projectArgs.api);
     }else{
-        Project = new Dexcalibur(projectArgs.app, null, projectArgs.nofrida);
+        Project = new Dexcalibur(projectArgs.app, null, projectArgs.nofrida, projectArgs.api);
     }
 
     if(projectArgs.useEmu)

--- a/src/AdbWrapper.js
+++ b/src/AdbWrapper.js
@@ -69,30 +69,31 @@ class AdbWrapper
         var reg = new RegExp("^package:(?<apk_name>.*)");
         var ret = "";
         if(deviceId !== null) {
-            ret = Process.execSync(this.setup(deviceId) + " pm list packages").toString("ascii");
+            ret = Process.execSync(this.setup(deviceId) + " shell pm list packages").toString("ascii");
             
         }
         else {
-            ret = Process.execSync(this.path + " pm list packages").toString("ascii");
+            ret = Process.execSync(this.path + " shell pm list packages").toString("ascii");
             
         }
-        packages = [];
-        buffer.split('\n').forEach(element => {
-            var package = element.trim();
-            if(reg.test(package)) {
-                var result  = reg.exec(package);
+        var packages = [];
+        ret.split('\n').forEach(element => {
+            var pkg = element.trim();
+            if(reg.test(pkg)) {
+                var result  = reg.exec(pkg);
                 if(result !== null) {
                     var pathResult = "";
+                    //getting the path for each package takes ages
                     if(deviceId !== null) {
-                        pathResult = Process.execSync(this.setup(deviceId) + " shell pm path " + result.groups['apk_name']).toString("ascii");
+                       // pathResult = Process.execSync(this.setup(deviceId) + " shell pm path " + result.groups['apk_name']).toString("ascii");
 
                     }
                     else {
-                        pathResult = Process.execSync(this.path + " shell pm path " + result.groups['apk_name']).toString("ascii");
+                       // pathResult = Process.execSync(this.path + " shell pm path " + result.groups['apk_name']).toString("ascii");
                     }
                     //recycle the same regex since the output is the same
                     //only take first match since this is the base apk
-                    pathResult = pathResult.split('\n')[0].trim();
+                    //pathResult = pathResult.split('\n')[0].trim();
                     if(reg.test(pathResult)) {
                         pathResult = reg.exec(pathResult).groups['apk_name'];
                     }

--- a/src/AdbWrapper.js
+++ b/src/AdbWrapper.js
@@ -187,7 +187,7 @@ class AdbWrapper
      * @param {*} local_path The path where the resource will be stored locally
      */
 
-    pull(package_name,remote_path, local_path, deviceID=null){
+    pullRessource(package_name,remote_path, local_path, deviceID=null){
         if(deviceID != null) {
             var binary_blob = Process.execSync(this.setup(deviceID) + 'shell "run-as '+ package_name+ ' cat ' + remote_path + '"').buffer;
             fs.writeFile(local_path,binary_blob,function(err) {

--- a/src/AdbWrapper.js
+++ b/src/AdbWrapper.js
@@ -1,6 +1,10 @@
 const Process = require("child_process");
 const UT = require("./Utils.js");
 const Device = require("./Device.js");
+const Package = require("./Package");
+
+
+const fs = require('fs');
 
 const TRANSPORT = {
     USB: 'U',
@@ -61,6 +65,46 @@ class AdbWrapper
         this.transport = transport_type;
     }
 
+    listPackages(deviceId = null) {
+        var reg = new RegExp("^package:(?<apk_name>.*)");
+        var ret = "";
+        if(deviceId !== null) {
+            ret = Process.execSync(this.setup(deviceId) + " pm list packages").toString("ascii");
+            
+        }
+        else {
+            ret = Process.execSync(this.path + " pm list packages").toString("ascii");
+            
+        }
+        packages = [];
+        buffer.split('\n').forEach(element => {
+            var package = element.trim();
+            if(reg.test(package)) {
+                var result  = reg.exec(package);
+                if(result !== null) {
+                    var pathResult = "";
+                    if(deviceId !== null) {
+                        pathResult = Process.execSync(this.setup(deviceId) + " shell pm path " + result.groups['apk_name']).toString("ascii");
+
+                    }
+                    else {
+                        pathResult = Process.execSync(this.path + " shell pm path " + result.groups['apk_name']).toString("ascii");
+                    }
+                    //recycle the same regex since the output is the same
+                    //only take first match since this is the base apk
+                    pathResult = pathResult.split('\n')[0].trim();
+                    if(reg.test(pathResult)) {
+                        pathResult = reg.exec(pathResult).groups['apk_name'];
+                    }
+                    packages.push(new Package({
+                        packageIdentifier: result.groups['apk_name'],
+                        packagePath : pathResult
+                    }));
+                }
+            }
+        });
+        return packages;
+    }
     listDevices(){
         let dev = [], ret=null,re=null, data=null, id=null, device=null;
 
@@ -115,8 +159,27 @@ class AdbWrapper
             return UT.execSync(this.path+' pull '+remote_path+' '+local_path);
     }
 
+    /**
+     * Pull a remote resource into the project workspace with Application Privileges
+     * Same as 'adb pull' commande.
+     * 
+     * @param {*} package_name The package name
+     * @param {*} remote_path The path of the remote resource to download 
+     * @param {*} local_path The path where the resource will be stored locally
+     */
 
-
+    pull(package_name,remote_path, local_path, deviceID=null){
+        if(deviceID != null) {
+            var binary_blob = Process.execSync(this.setup(deviceID) + 'shell "run-as '+ package_name+ ' cat ' + remote_path + '"').buffer;
+            fs.writeFile(local_path,binary_blob,function(err) {
+                if(err) {
+                    return console.log(err);
+                }
+            
+                console.log("The file was saved!");
+            });
+        }
+    }
     /**
      * Push a local resource to a remote location
      * Same as 'adb push' commande.

--- a/src/AdbWrapper.js
+++ b/src/AdbWrapper.js
@@ -99,12 +99,30 @@ class AdbWrapper
                     }
                     packages.push(new Package({
                         packageIdentifier: result.groups['apk_name'],
-                        packagePath : pathResult
+                        packagePath : pathResult,
+                        
                     }));
                 }
             }
         });
         return packages;
+    }
+    getPackagePath(packageIdentifier, deviceId=null) {
+        var reg = new RegExp("^package:(?<package_name>.*)");
+        var ret = "";
+        if(deviceId !== null) {
+            ret = Process.execSync(this.setup(deviceId) + " shell pm path " +  packageIdentifier).toString("ascii");
+            
+        }
+        else {
+            ret = Process.execSync(this.path + " shell pm path " + packageIdentifier).toString("ascii");
+        }
+        var path = ret.split('\n')[0].trim();
+        if(reg.test(path)) {
+            path = reg.exec(path).groups["package_name"];
+            return path;
+        }
+        return "";
     }
     listDevices(){
         let dev = [], ret=null,re=null, data=null, id=null, device=null;

--- a/src/AdbWrapper.js
+++ b/src/AdbWrapper.js
@@ -1,7 +1,7 @@
 const Process = require("child_process");
 const UT = require("./Utils.js");
 const Device = require("./Device.js");
-const Package = require("./Package");
+const ApkPackage = require("./AppPackage");
 
 
 const fs = require('fs');
@@ -97,7 +97,7 @@ class AdbWrapper
                     if(reg.test(pathResult)) {
                         pathResult = reg.exec(pathResult).groups['apk_name'];
                     }
-                    packages.push(new Package({
+                    packages.push(new ApkPackage({
                         packageIdentifier: result.groups['apk_name'],
                         packagePath : pathResult,
                         

--- a/src/ApkHelper.js
+++ b/src/ApkHelper.js
@@ -20,7 +20,7 @@ ApkHelper.prototype.extract = function(fileSrc, folderDest=null, resource=false)
     let cmd = this.context.config.apktPath+" d ";
     if(!resource)  cmd += "-r";
 
-    ret = Process.execSync(cmd+"-f -m -o "+folderDest+" "+file).toString("ascii");
+    ret = Process.execSync(cmd+" -f -m -o "+folderDest+" "+fileSrc).toString("ascii");
     
     //if()
     console.log(Chalk.bold.green("[*] APK decompiled in "+folderDest));

--- a/src/AppPackage.js
+++ b/src/AppPackage.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 var Path = require("path");
 
-class Package {
+class ApkPackage {
     constructor(config=null){
         this.config = config;
        
@@ -9,6 +9,7 @@ class Package {
         this.packagePath =  null;
         this.patched = false;
         this.workspaceExists = false; //
+        this.currentWd = false;
         if(config !== null)
             for(let i in config)
             {
@@ -31,4 +32,4 @@ class Package {
     }
 }
 
-module.exports = Package;
+module.exports = ApkPackage;

--- a/src/Package.js
+++ b/src/Package.js
@@ -1,0 +1,23 @@
+class Package {
+    constructor(config=null){
+        this.packageIdentifier = null;
+        this.packagePath =  null;
+        this.patched = false;
+        if(config !== null)
+            for(let i in config) this[i] = config[i]; 
+    }
+
+
+    /**
+     * To serialize the Device to JSON string
+     * @returns {String} JSON-serialized object
+     * @function 
+     */
+    toJsonObject(){
+        let json = new Object();
+        for(let i in this){
+            json[i] = this[i];
+        }
+        return json;
+    }
+}

--- a/src/Package.js
+++ b/src/Package.js
@@ -21,3 +21,5 @@ class Package {
         return json;
     }
 }
+
+module.exports = Package;

--- a/src/Package.js
+++ b/src/Package.js
@@ -1,10 +1,19 @@
+const fs = require('fs');
+var Path = require("path");
+
 class Package {
     constructor(config=null){
+        this.config = config;
+       
         this.packageIdentifier = null;
         this.packagePath =  null;
         this.patched = false;
+        this.workspaceExists = false; //
         if(config !== null)
-            for(let i in config) this[i] = config[i]; 
+            for(let i in config)
+            {
+                this[i] = config[i];
+            }
     }
 
 

--- a/src/PackagePatcher.js
+++ b/src/PackagePatcher.js
@@ -31,7 +31,7 @@ class PackagePatcher {
         
         fs.mkdirSync(projectDir);
         fs.mkdirSync(dstPath);
-        
+
         var pathResult = this.Bridges.ADB.getPackagePath(packageIdentifier);
         this.Bridges.ADB.pull(pathResult, tmpPath);
         this.apkHelper.extract(tmpPath, dstPath);
@@ -45,7 +45,7 @@ class PackagePatcher {
 
            for(let i in pkgs){
                this.packages[pkgs[i].packageIdentifier] = pkgs[i];
-               this.packages[pkgs[i].packageIdentifier].config.workspacePath = this.config.workspacePath;
+               this.packages[pkgs[i].packageIdentifier].workspaceExists = fs.existsSync(Path.join(this.config.workspacePath,pkgs[i].packageIdentifier));
            }
            //ut.msgBox("Android packages", Object.keys(this.packages));
            console.log("Android packages", Object.keys(this.packages));

--- a/src/PackagePatcher.js
+++ b/src/PackagePatcher.js
@@ -1,0 +1,46 @@
+const Adb = require('./AdbWrapper');
+
+class PackagePatcher {
+    constructor(config=null) {
+        this.Bridges = {
+            ADB: new AdbWrapper(this.config.getAdbPath(),null)
+        };
+    }
+    /**
+     * Pull a Package from the Device and Patch its MainActivity to load frida-gadget,
+     * as well as copying the library into the apk
+     * 
+     * @param {*} package_name The package name
+     * 
+     */
+    patchPackage(package_identifier) {
+        
+    }
+
+    scan(){
+        // TODO : scan for new devices
+        let ret="", packages=[], device=null,re=null,id=null;
+
+       this.count = 0;
+       if(this.Bridges.ADB.isReady()){
+           pkgs = this.Bridges.ADB.listPackages();
+           this.count += pkgss.length;
+
+           for(let i in pkgs){
+               this.packages[pks[i].packageIdentifier] = pkgs[i];
+           }
+           ut.msgBox("Android packages", Object.keys(this.packages));
+       }
+        
+   }
+
+   toJsonObject(){
+    let json = [];
+    for(let i in this.packages){
+        json.push(this.packages[i].toJsonObject())
+    }
+    return json;
+};
+
+    
+}

--- a/src/PackagePatcher.js
+++ b/src/PackagePatcher.js
@@ -1,9 +1,11 @@
-const Adb = require('./AdbWrapper');
+const Adb = require('./AdbWrapper.js');
 
 class PackagePatcher {
     constructor(config=null) {
+        this.config = config;
+        this.packages = [];
         this.Bridges = {
-            ADB: new AdbWrapper(this.config.getAdbPath(),null)
+            ADB: new Adb(this.config.getAdbPath(),null)
         };
     }
     /**
@@ -18,18 +20,16 @@ class PackagePatcher {
     }
 
     scan(){
-        // TODO : scan for new devices
-        let ret="", packages=[], device=null,re=null,id=null;
-
        this.count = 0;
        if(this.Bridges.ADB.isReady()){
-           pkgs = this.Bridges.ADB.listPackages();
-           this.count += pkgss.length;
+           var pkgs = this.Bridges.ADB.listPackages();
+           this.count += pkgs.length;
 
            for(let i in pkgs){
-               this.packages[pks[i].packageIdentifier] = pkgs[i];
+               this.packages[pkgs[i].packageIdentifier] = pkgs[i];
            }
-           ut.msgBox("Android packages", Object.keys(this.packages));
+           //ut.msgBox("Android packages", Object.keys(this.packages));
+           console.log("Android packages", Object.keys(this.packages));
        }
         
    }
@@ -44,3 +44,5 @@ class PackagePatcher {
 
     
 }
+
+module.exports = PackagePatcher;

--- a/src/PackagePatcher.js
+++ b/src/PackagePatcher.js
@@ -4,8 +4,9 @@ const Process = require('child_process');
 const fs = require('fs');
 
 class PackagePatcher {
-    constructor(config=null, apkHelper) {
+    constructor(pkgName,config=null, apkHelper) {
         this.apkHelper = apkHelper;
+        this.currentPackageName = pkgName;
         this.config = config;
         this.packages = [];
         this.Bridges = {
@@ -46,6 +47,7 @@ class PackagePatcher {
            for(let i in pkgs){
                this.packages[pkgs[i].packageIdentifier] = pkgs[i];
                this.packages[pkgs[i].packageIdentifier].workspaceExists = fs.existsSync(Path.join(this.config.workspacePath,pkgs[i].packageIdentifier));
+               this.packages[pkgs[i].packageIdentifier].currentWd = pkgs[i].packageIdentifier === this.currentPackageName;
            }
            //ut.msgBox("Android packages", Object.keys(this.packages));
            console.log("Android packages", Object.keys(this.packages));

--- a/src/PackagePatcher.js
+++ b/src/PackagePatcher.js
@@ -1,7 +1,10 @@
 const Adb = require('./AdbWrapper.js');
+const Path = require('path');
+const Process = require('child_process');
 
 class PackagePatcher {
-    constructor(config=null) {
+    constructor(config=null, apkHelper) {
+        this.apkHelper = apkHelper;
         this.config = config;
         this.packages = [];
         this.Bridges = {
@@ -15,7 +18,16 @@ class PackagePatcher {
      * @param {*} package_name The package name
      * 
      */
-    patchPackage(package_identifier) {
+    patchPackage(packageIdentifier) {
+        
+    }
+
+    pullPackage(packageIdentifier) {
+      
+        var dstPath = Path.join(this.config.workspacePath, "tmp", packageIdentifier);
+        var pathResult = this.Bridges.ADB.getPackagePath(packageIdentifier);
+        this.Bridges.ADB.pull(pathResult, dstPath);
+        this.apkHelper.extract(dstPath);
         
     }
 
@@ -27,6 +39,7 @@ class PackagePatcher {
 
            for(let i in pkgs){
                this.packages[pkgs[i].packageIdentifier] = pkgs[i];
+               this.packages[pkgs[i].packageIdentifier].config.workspacePath = this.config.workspacePath;
            }
            //ut.msgBox("Android packages", Object.keys(this.packages));
            console.log("Android packages", Object.keys(this.packages));

--- a/src/PackagePatcher.js
+++ b/src/PackagePatcher.js
@@ -1,6 +1,7 @@
 const Adb = require('./AdbWrapper.js');
 const Path = require('path');
 const Process = require('child_process');
+const fs = require('fs');
 
 class PackagePatcher {
     constructor(config=null, apkHelper) {
@@ -23,12 +24,17 @@ class PackagePatcher {
     }
 
     pullPackage(packageIdentifier) {
-      
-        var dstPath = Path.join(this.config.workspacePath, "tmp", packageIdentifier);
-        var pathResult = this.Bridges.ADB.getPackagePath(packageIdentifier);
-        this.Bridges.ADB.pull(pathResult, dstPath);
-        this.apkHelper.extract(dstPath);
+        var dstPath = Path.join(this.config.workspacePath, packageIdentifier, 'dex');
+        var tmpPath = Path.join(this.config.workspacePath,packageIdentifier, packageIdentifier +  '.apk');
+
+        var projectDir = Path.join(this.config.workspacePath, packageIdentifier);
         
+        fs.mkdirSync(projectDir);
+        fs.mkdirSync(dstPath);
+        
+        var pathResult = this.Bridges.ADB.getPackagePath(packageIdentifier);
+        this.Bridges.ADB.pull(pathResult, tmpPath);
+        this.apkHelper.extract(tmpPath, dstPath);
     }
 
     scan(){

--- a/src/Project.js
+++ b/src/Project.js
@@ -106,7 +106,7 @@ function Project(pkgName, cfgpath=null, nofrida=0){
     this.devices = new DeviceManager(this.config);
 
     //package Patcher
-    this.packagePatcher = new PackagePatcher(this.config);
+    this.packagePatcher = new PackagePatcher(this.config, this.apkHelper);
 
     // hook
     this.hook = new HookHelper.Manager(this, nofrida);

--- a/src/Project.js
+++ b/src/Project.js
@@ -64,7 +64,8 @@ function importConfig(cfg){
 function Project(pkgName, cfgpath=null, nofrida=0){
     this.pkg = pkgName;
     this.config = new Configuration();
-
+    this.cfgpath = cfgpath;
+    this.nofrida = nofrida;
     var _self = this;
 
     if(cfgpath != null){
@@ -201,6 +202,13 @@ function Project(pkgName, cfgpath=null, nofrida=0){
 
     this.workspace.init();
 }
+
+Project.prototype.changeProject = function(packageIdentifier) {
+    this.pkg = packageIdentifier;
+    this.workspace = new Workspace(packageIdentifier,this.config);
+    this.workspace.init();
+    this.fullscan();
+};
 
 Project.prototype.getAnalyzer = function(){
     return this.analyze;

--- a/src/Project.js
+++ b/src/Project.js
@@ -10,6 +10,7 @@ var Analyzer = require("./Analyzer.js");
 var AnalysisHelper = require("./AnalysisHelper.js");
 var Finder = require("./Finder.js");
 var DeviceManager = require("./DeviceManager.js");
+var PackagePatcher = require("./PackagePatcher.js");
 //var ut = require("./Utils.js");
 //var Backup = require("./BackupManager.js");
 var HookHelper = require("./HookManager.js");
@@ -103,6 +104,9 @@ function Project(pkgName, cfgpath=null, nofrida=0){
 
     // ste Device Manager
     this.devices = new DeviceManager(this.config);
+
+    //package Patcher
+    this.packagePatcher = new PackagePatcher(this.config);
 
     // hook
     this.hook = new HookHelper.Manager(this, nofrida);

--- a/src/Project.js
+++ b/src/Project.js
@@ -445,22 +445,16 @@ Project.prototype.pull = function(device){
     let pathWD = Path.join(this.workspace.getWD(),this.pkg);
     let dexPath = Path.join(this.workspace.getWD(),"dex");
 
-    ret = Process.execSync(
-        adb+" pull "+ppath+" "+pathWD+".apk"
-    ).toString("ascii");
-
-
-    /*
-    We should find another way to check if "adb pull" is done successfully
-    */
-    if(ret.indexOf("1 file pulled")>-1){
+    try {
+        Process.execSync(adb+" pull "+ppath+" "+pathWD+".apk");
         console.log(Chalk.bold.green("[*] Package downloaded to "+pathWD+".apk"));
 
         ret = Process.execSync(this.config.apktPath+" d -f -m -r -o "+dexPath+" "+pathWD+".apk").toString("ascii");
         console.log(Chalk.bold.green("[*] APK decompiled in "+dexPath));
-
-    }else{
-        console.error(Chalk.bold.red("[!] Fail to pull package"));
+    }
+    catch(exception) {
+        console.error(Chalk.bold.red("[!] Failed to pull package:"));
+        console.error(exception);
     }
 };
 

--- a/src/Project.js
+++ b/src/Project.js
@@ -62,10 +62,15 @@ function importConfig(cfg){
  * @constructor
  */
 function Project(pkgName, cfgpath=null, nofrida=0){
+    this.initDexcalibur(pkgName,cfgpath,nofrida);
+}
+
+Project.prototype.initDexcalibur = function(pkgName, cfgpath=null, nofrida=0, apiVersion="android:7.0.0"){
     this.pkg = pkgName;
     this.config = new Configuration();
     this.cfgpath = cfgpath;
     this.nofrida = nofrida;
+    this.apiVersion = apiVersion;
     var _self = this;
 
     if(cfgpath != null){
@@ -107,7 +112,7 @@ function Project(pkgName, cfgpath=null, nofrida=0){
     this.devices = new DeviceManager(this.config);
 
     //package Patcher
-    this.packagePatcher = new PackagePatcher(this.config, this.apkHelper);
+    this.packagePatcher = new PackagePatcher(pkgName, this.config, this.apkHelper);
 
     // hook
     this.hook = new HookHelper.Manager(this, nofrida);
@@ -204,10 +209,8 @@ function Project(pkgName, cfgpath=null, nofrida=0){
 }
 
 Project.prototype.changeProject = function(packageIdentifier) {
-    this.pkg = packageIdentifier;
-    this.workspace = new Workspace(packageIdentifier,this.config);
-    this.workspace.init();
-    this.fullscan();
+    this.initDexcalibur(packageIdentifier,this.cfgpath,this.nofrida);
+    this.useAPI(this.apiVersion).fullscan();
 };
 
 Project.prototype.getAnalyzer = function(){

--- a/src/WebServer.js
+++ b/src/WebServer.js
@@ -228,6 +228,16 @@ class WebServer {
                 };
                 res.status(200).send(JSON.stringify(dev));
             });
+            this.app.route('/api/package')
+            .get(function(req,res){
+                // scan connected devices
+                $.project.packagePatcher.scan();
+                // collect
+                let packages = {
+                    data: $.project.packagePatcher.toJsonObject()
+                };
+                res.status(200).send(JSON.stringify(packages));
+            });
 
         // not used
         this.app.route('/api/stats')

--- a/src/WebServer.js
+++ b/src/WebServer.js
@@ -238,6 +238,14 @@ class WebServer {
                 };
                 res.status(200).send(JSON.stringify(packages));
             });
+            this.app.route('/api/pullProject/:packageIdentifier')
+            .get(function(req,res){
+                // scan connected devices
+                //console.log(req.params.packageIdentifier)
+                $.project.packagePatcher.pullPackage(req.params.packageIdentifier);
+                // collect
+                res.status(200).send(JSON.stringify({message: "ok"}));
+            });
 
         // not used
         this.app.route('/api/stats')

--- a/src/WebServer.js
+++ b/src/WebServer.js
@@ -228,7 +228,7 @@ class WebServer {
                 };
                 res.status(200).send(JSON.stringify(dev));
             });
-            this.app.route('/api/package')
+            this.app.route('/api/packageList')
             .get(function(req,res){
                 // scan connected devices
                 $.project.packagePatcher.scan();
@@ -237,6 +237,14 @@ class WebServer {
                     data: $.project.packagePatcher.toJsonObject()
                 };
                 res.status(200).send(JSON.stringify(packages));
+            });
+            this.app.route('/api/changeWorkspace/:projectIdentifier')
+            .get(function(req,res){
+                // scan connected devices
+                $.project.changeProject(req.params.projectIdentifier);
+                // collect
+                
+                res.status(200).send("{\"status\": \"ok\"}");
             });
             this.app.route('/api/pullProject/:packageIdentifier')
             .get(function(req,res){

--- a/src/WebServer.js
+++ b/src/WebServer.js
@@ -244,6 +244,7 @@ class WebServer {
                 //console.log(req.params.packageIdentifier)
                 $.project.packagePatcher.pullPackage(req.params.packageIdentifier);
                 // collect
+                $.project.changeProject(req.params.packageIdentifier);
                 res.status(200).send(JSON.stringify({message: "ok"}));
             });
 

--- a/src/webserver/public/pages/inc/menu.html
+++ b/src/webserver/public/pages/inc/menu.html
@@ -51,6 +51,9 @@
                 <li>
                     <a href="/pages/devicemanager.html"><i class="fa fa-tablet fa-fw" style="size:1em"></i> Device manager</a>
                 </li>
+                <li>
+                    <a href="/pages/packagepatcher.html"><i class="fa fa-tablet fa-fw" style="size:1em"></i> Package patcher</a>
+                </li>
             </ul>
         </div>
         <!-- /.sidebar-collapse -->

--- a/src/webserver/public/pages/packagepatcher.html
+++ b/src/webserver/public/pages/packagepatcher.html
@@ -59,7 +59,8 @@
                                     <tr>
                                         <th>Package Identifier</th>
                                         
-                                        <!--<th>Action</th>-->
+                                        <th>Pull</th>
+                                        <th>Patch</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -106,7 +107,20 @@
         let dmTable = $('#dataTables-example').DataTable({
             ajax: "../api/package",
             columns: [
-                { data: 'packageIdentifier' }
+                { data: 'packageIdentifier' },
+                {
+                    render: function(data, type, row, meta) {
+                        if(!row.workspaceExists) {
+                        return `&nbsp;<button style="height:1.5em;padding-top:0px;padding-bottom:0px;" class="btn btn-success pull-apk" package="`+row.packageIdentifier+`">Pull</button>`;
+                        }
+                        return "<div>Already pulled </div>";
+                    }
+                },
+                {
+                    render: function(data, type, row, meta) {
+                        return `&nbsp;<button style="height:1.5em;padding-top:0px;padding-bottom:0px;" class="btn btn-success patch-apk" package="`+row.packageIdentifier+`">Patch</button>`;
+                    }
+                }
             ],
             responsive: true
         });
@@ -121,7 +135,20 @@
         $('#dm-refresh-btn').click(()=>{
             dmTable.ajax.reload();
         });
+
+
+        $('#dataTables-example tbody').on('click', 'button.pull-apk', function () {
+           // alert("test");
+            let id = $(this).attr("package");
+            location.href = "/api/pullProject/" + id;
+        });
+        $('#dataTables-example tbody').on('click', 'button.patch-apk', function () {
+            let id = $(this).attr("package");
+            location.href = "/api/patchProject/" + id;
+        });
     });
+
+   
     </script>
 
 </body>

--- a/src/webserver/public/pages/packagepatcher.html
+++ b/src/webserver/public/pages/packagepatcher.html
@@ -140,7 +140,11 @@
         $('#dataTables-example tbody').on('click', 'button.pull-apk', function () {
            // alert("test");
             let id = $(this).attr("package");
-            location.href = "/api/pullProject/" + id;
+            $(this).attr("disabled", 'true')
+            $.getJSON("/api/pullProject/" + id, function(success) {
+                alert("Downloaded package");
+                dmTable.ajax.reload();
+            });
         });
         $('#dataTables-example tbody').on('click', 'button.patch-apk', function () {
             let id = $(this).attr("package");

--- a/src/webserver/public/pages/packagepatcher.html
+++ b/src/webserver/public/pages/packagepatcher.html
@@ -44,7 +44,7 @@
                     <div class="panel panel-default">
                         <div class="panel-heading">
                             <div class="row">
-                                <div class="col-lg-11"><h4>List of devices registered</h4></div>
+                                <div class="col-lg-11"><h4>List of packages found on device</h4></div>
                                 <div class="col-lg-1">
                                     <button id="dm-refresh-btn" class="btn btn-primary" type="button">
                                         <i class="fa fa-refresh"></i>
@@ -58,7 +58,7 @@
                                 <thead>
                                     <tr>
                                         <th>Package Identifier</th>
-                                        <th>Package Path</th>
+                                        
                                         <!--<th>Action</th>-->
                                     </tr>
                                 </thead>
@@ -106,8 +106,7 @@
         let dmTable = $('#dataTables-example').DataTable({
             ajax: "../api/package",
             columns: [
-                { data: 'packageIdentifier' },
-                { data: 'packagePath' }
+                { data: 'packageIdentifier' }
             ],
             responsive: true
         });

--- a/src/webserver/public/pages/packagepatcher.html
+++ b/src/webserver/public/pages/packagepatcher.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title>Dexcalibur - Device Manager</title>
+
+    <!-- styles -->
+    <!--## pages/inc/tpl_css.html ##-->
+
+
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+        <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+        <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+    <![endif]-->
+
+</head>
+
+<body>
+
+    <div id="wrapper">
+
+        <!-- Navigation -->
+        <!--## pages/inc/menu.html ##-->
+
+        <div id="page-wrapper">
+            <div class="row">
+                <div class="col-lg-12">
+                    <h1 class="page-header">Package patcher</h1>
+                </div>
+                <!-- /.col-lg-12 -->
+            </div>
+            <!-- /.row -->
+            <div class="row">
+                <div class="col-lg-12">
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <div class="row">
+                                <div class="col-lg-11"><h4>List of devices registered</h4></div>
+                                <div class="col-lg-1">
+                                    <button id="dm-refresh-btn" class="btn btn-primary" type="button">
+                                        <i class="fa fa-refresh"></i>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- /.panel-heading -->
+                        <div class="panel-body">
+                            <table width="100%" class="table table-striped table-bordered table-hover" id="dataTables-example">
+                                <thead>
+                                    <tr>
+                                        <th>Package Identifier</th>
+                                        <th>Package Path</th>
+                                        <!--<th>Action</th>-->
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    
+                                </tbody>
+                            </table>
+                            <!-- /.table-responsive -->
+                        </div>
+                        <!-- /.panel-body -->
+                    </div>
+                    <!-- /.panel -->
+                </div>
+                <!-- /.col-lg-12 -->
+            </div>
+            <!-- /.row -->
+        </div>
+        <!-- /#page-wrapper -->
+
+    </div>
+    <!-- /#wrapper -->
+
+    <!-- jQuery -->
+    <script src="../vendor/jquery/jquery.min.js"></script>
+
+    <!-- Bootstrap Core JavaScript -->
+    <script src="../vendor/bootstrap/js/bootstrap.min.js"></script>
+
+    <!-- Metis Menu Plugin JavaScript -->
+    <script src="../vendor/metisMenu/metisMenu.min.js"></script>
+
+    <!-- DataTables JavaScript -->
+    <!--<script src="../vendor/datatables/js/jquery.dataTables.min.js"></script>-->
+    <script src="../vendor/datatables/js/jquery.dataTables.js"></script>
+    <script src="../vendor/datatables-plugins/dataTables.bootstrap.min.js"></script>
+    <script src="../vendor/datatables-responsive/dataTables.responsive.js"></script>
+
+    <!-- Custom Theme JavaScript -->
+    <script src="../dist/js/sb-admin-2.js"></script>
+
+    <!-- Page-Level Demo Scripts - Tables - Use for reference -->
+    <script>
+    $(document).ready(function() {
+
+        let dmTable = $('#dataTables-example').DataTable({
+            ajax: "../api/package",
+            columns: [
+                { data: 'packageIdentifier' },
+                { data: 'packagePath' }
+            ],
+            responsive: true
+        });
+        //console.log(dmTable);
+        /*dmTable.on( 'xhr', function () {
+            dmTable.ajax.load();
+            //alert( json.data.length +' row(s) were loaded' );
+        } );*/
+
+
+        //dmTable.ajax.url("../api/device").load();
+        $('#dm-refresh-btn').click(()=>{
+            dmTable.ajax.reload();
+        });
+    });
+    </script>
+
+</body>
+
+</html>

--- a/src/webserver/public/pages/packagepatcher.html
+++ b/src/webserver/public/pages/packagepatcher.html
@@ -22,6 +22,62 @@
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
 
+    <style>
+        .pulsating-circle {
+            width: 30px;
+            height: 30px;
+        }
+  
+  .pulsating-circle:before {
+    content: '';
+    position: relative;
+    display: block;
+    width: 300%;
+    height: 300%;
+    box-sizing: border-box;
+    margin-left: -100%;
+    margin-top: -100%;
+    border-radius: 45px;
+    background-color: #01a4e9;
+    animation: pulse-ring 1.25s cubic-bezier(0.215, 0.61, 0.355, 1) infinite;
+  }
+  
+  .pulsating-circle:after {
+    content: '';
+    position: relative;
+    display: block;
+   
+    margin-top: -200%;
+    width: 100%;
+    height: 100%;
+    background-color: gray;
+    border-radius: 15px;
+    box-shadow: 0 0 8px rgba(0,0,0,.3);
+    animation: pulse-dot 1.25s cubic-bezier(0.455, 0.03, 0.515, 0.955) -.4s infinite;
+  }
+
+@keyframes pulse-ring {
+  0% {
+    transform: scale(.33);
+  }
+  80%, 100% {
+    opacity: 0;
+  }
+}
+
+@keyframes pulse-dot {
+  0% {
+    transform: scale(.8);
+  }
+  50% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(.8);
+  }
+}
+    </style>
+
 </head>
 
 <body>
@@ -105,7 +161,7 @@
     $(document).ready(function() {
 
         let dmTable = $('#dataTables-example').DataTable({
-            ajax: "../api/package",
+            ajax: "../api/packageList",
             columns: [
                 { data: 'packageIdentifier' },
                 {
@@ -113,7 +169,10 @@
                         if(!row.workspaceExists) {
                         return `&nbsp;<button style="height:1.5em;padding-top:0px;padding-bottom:0px;" class="btn btn-success pull-apk" package="`+row.packageIdentifier+`">Pull</button>`;
                         }
-                        return "<div>Already pulled </div>";
+                        else if(row.currentWd) {
+                            return `<div>Current Workspace</div>`;
+                        }
+                        return `<div><button style="height:1.5em;padding-top:0px;padding-bottom:0px;" class="btn btn-success change-workspace" package="`+row.packageIdentifier+`">Change Workspace</button> </div>`;
                     }
                 },
                 {
@@ -140,15 +199,23 @@
         $('#dataTables-example tbody').on('click', 'button.pull-apk', function () {
            // alert("test");
             let id = $(this).attr("package");
-            $(this).attr("disabled", 'true')
+            $(this).parent().replaceWith(`<div class="pulsating-circle"></div>`);
             $.getJSON("/api/pullProject/" + id, function(success) {
-                alert("Downloaded package");
+                
                 dmTable.ajax.reload();
             });
         });
         $('#dataTables-example tbody').on('click', 'button.patch-apk', function () {
+            //let id = $(this).attr("package");
+            //location.href = "/api/patchProject/" + id;
+        });
+        $('#dataTables-example tbody').on('click', 'button.change-workspace', function () {
             let id = $(this).attr("package");
-            location.href = "/api/patchProject/" + id;
+            $(this).parent().replaceWith(`<div class="pulsating-circle"></div>`);
+            $.getJSON("/api/changeWorkspace/" + id, function(success) {
+                dmTable.ajax.reload();
+            });
+
         });
     });
 


### PR DESCRIPTION
This commit introduces a new page which lists the packages found on the device. It is a rather early phase and definitely needs some styling :D 

On this page it should mark the current active project as "Current Workspace". Further, it allows you to pull packages from the device and analyse  it. If you pull a package, it automatically reinitialises dexcalibur to point to the new workspace. If there are multiple projects in the dexcalibur workspace, the package-manager allows you to change between them

I put some loading blob to indicate the processing. 