### PR TITLE
fix device list bug

### DIFF
--- a/src/AdbWrapper.js
+++ b/src/AdbWrapper.js
@@ -130,7 +130,7 @@ class AdbWrapper
         ret = Process.execSync(this.setup()+" devices -l").toString("ascii");
         ret = ret.split("\n");
         //re = new RegExp("([0-9A-Za-f]+).*device\susb:([^\s]+)\sproduct:([^\s]+)\smodel:([^\s]+)\sdevice:([^\s]+)");
-        re = new RegExp("^([0-9A-Za-z-]+).*device (.*)$");
+        re = new RegExp("^([0-9A-Za-z-\.\:]+).*device (.*)$");
         
         for(let ln in ret){
             if(UT.trim(ret[ln]).length==0 


### PR DESCRIPTION
Sometimes `adb devices` include ip address. Such as :
```
adb devices -l
List of devices attached
192.168.57.105:5555    device product:vbox86p model:Google device:vbox86p transport_id:1
```
Since regex doesn't have `.` and `:` it fails to get name correctly.
```
[*] Device selected : 192
error: device '192' not found
child_process.js:660
    throw err;
```
This fixes the issue
```
╔═══════════════════════════[ Android devices ]═══════════════════════════════╗
║ 192.168.57.105:5555                                                         ║
╚═════════════════════════════════════════════════════════════════════════════╝

[*] Device selected : 192.168.57.105:5555
```
