### PR TITLE
Fixed a regex on getprop

### DIFF
--- a/src/AdbWrapper.js
+++ b/src/AdbWrapper.js
@@ -21,7 +21,7 @@ const TRANSPORT = {
 };
 
 const emuRE = /^emulator-/;
-const PROP_RE = /^\[(?<name>.*)\]\s*:\s*\[(?<value>.*)\]$/;
+const PROP_RE = /^\[(?<name>.*)\]\s*:\s*\[(?<value>.*)\]\s*$/;
 
 /*
 const DEV = {


### PR DESCRIPTION
Add a `\s*` at the end of `PROP_RE` to catch some corner cases.
On my device (Sony Xperia Z1 (C6903)), lines returned by `adb getprop` end with `\r\n`. So the regex would not match anything.
