### PR TITLE
DeviceManager: Fix updateDeviceList()

### DIFF
--- a/src/DeviceManager.js
+++ b/src/DeviceManager.js
@@ -287,7 +287,7 @@ class DeviceManager
                     b = this.devices[i].bridges[k];
                     if(b.isNetworkTransport()){
                         d = this.getDeviceByIP(b.ip, b.port, false);
-                        if(d == null){
+                        if(d != null){
                             devs[this.devices[i].uid] = this.devices[i];
                         }
                     }else{


### PR DESCRIPTION
## Env

- **Dexcalibur:** v0.7.9
- **Host:** MacOS Big Sur

### Expected behaviour

- Device listing works regardless of the ADB connection (USB, network).

### Actual behaviour

- When using `adb+tcp` devices wont be listed in dexcalibur.

### Issue

```js
...
            if(this.devices[i].id=="<pending...>"){
                for(let k in this.devices[i].bridges){
                    b = this.devices[i].bridges[k];
                    if(b.isNetworkTransport()){
                        d = this.getDeviceByIP(b.ip, b.port, false);
                        if(d == null){
                            devs[this.devices[i].uid] = this.devices[i];
                        }
                    }else{
                        d = this.getDeviceByID(b.deviceID);

                        if(d == null){
                            devs[this.devices[i].uid] = this.devices[i];
                        }
                    }
                }
....
```

As seen in above piece of code, when doing `d = this.getDeviceByIP(b.ip, b.port, false);` afterwards `d` wont have a `null` value, but since the if statement is set to `== null`, the device wont be added to the active devices list. 

### Solution

The solution is easy, as proposed in this pull request, just needs to update the if statement to `!= null`.

CC: @cryptax