### PR TITLE
Fix typo on adb.exe

### DIFF
--- a/src/DeviceManager.js
+++ b/src/DeviceManager.js
@@ -74,7 +74,7 @@ class DeviceManager
                 _path_.join(
                     this.dxcWorkspace.getBinaryFolderLocation(),
                     "platform-tools",
-                    (require('os').platform()==="win32"? "abd.exe":"adb")
+                    (require('os').platform()==="win32"? "adb.exe":"adb")
                 )
             )
         };


### PR DESCRIPTION
**Description:**
- Fix typo (from `abd.exe` to `adb.exe`)
- This typo causes dexcalibur crash on Windows

**File changed:**
- src/DeviceManager.js