### PR TITLE
Adding a working Dockerfile to run Dexcalibur

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Don't hesitate ! There are several ways to contribute :
 
 Go to [Install doc](https://frenchyeti.github.io/dexcalibur-doc/Installation-guide.html)
 
+Alternative: use Docker
+
+- on your host, install `adb` (and an Android emulator if appropriate)
+- `docker-compose build android-dexcalibur`
+- `docker run --rm -it --net=host -v /tmp/dexcalibur:/shared -p 8000:8000 dexcalibur:2023.01 /bin/bash`
+
 
 ### A.2 Launch dexcalibur
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+---
+version: "3"
+services:
+  android-dexcalibur:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: dexcalibur:2023.01
+    container_name: android-dexcalibur
+    network_mode: "host"
+    volumes:
+      - /tmp/dexcalibur:/shared


### PR DESCRIPTION
This is a working Dockerfile with a recent NodeJS.
Then, you need to launch the container. It's important to use `--net=host` to share communication with the host and its Android device (plugged via USB, or emulator).